### PR TITLE
cidr_network: fix panic if no `mask` supplied

### DIFF
--- a/internal/provider/data_source_network.go
+++ b/internal/provider/data_source_network.go
@@ -33,6 +33,7 @@ func dataSourceNetwork() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
+				RequiredWith:     []string{"ip", "mask"},
 				ValidateDiagFunc: validation.ToDiagFunc(validation.IsIPAddress),
 			},
 			"mask": {
@@ -40,7 +41,6 @@ func dataSourceNetwork() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				RequiredWith:     []string{"ip"},
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 			},
 			"mask_bits": {


### PR DESCRIPTION
The following configuration causes Terraform to crash:

```terraform
data "cidr_network" "example" {
  ip = "192.168.2.57"
}
```

```
Error: rpc error: code = Unavailable desc = transport is closing


panic: runtime error: invalid memory address or nil pointer dereference
2021-04-03T23:42:45.839+0200 [DEBUG] plugin.terraform-provider-cidr_v0.1.0.exe: [signal 0xc0000005 code=0x0 addr=0x10 pc=0xad157e]
2021-04-03T23:42:45.839+0200 [DEBUG] plugin.terraform-provider-cidr_v0.1.0.exe:
2021-04-03T23:42:45.839+0200 [DEBUG] plugin.terraform-provider-cidr_v0.1.0.exe: goroutine 56 [running]:
2021-04-03T23:42:45.839+0200 [DEBUG] plugin.terraform-provider-cidr_v0.1.0.exe: github.com/apparentlymart/go-cidr/cidr.AddressRange(0x0, 0xc5607b, 0x4, 0xb3f2c0, 0x12c6960, 0x453a00, 0xc0004d62d8)
2021-04-03T23:42:45.839+0200 [DEBUG] plugin.terraform-provider-cidr_v0.1.0.exe:         github.com/apparentlymart/go-cidr@v1.1.0/cidr/cidr.go:108 +0x3e
2021-04-03T23:42:45.839+0200 [DEBUG] plugin.terraform-provider-cidr_v0.1.0.exe: github.com/volcano-coffee-company/terraform-provider-cidr/internal/provider.dataSourceNetworkRead(0xd77e00, 0xc00028a660, 0xc000290500, 0x0, 0x0, 0xc0001f5d20, 0xc0004e5950, 0x40d3ff)
...
```

Either `prefix` or both `ip` and `mask` must be set.

Expected the following error when no `mask` is supplied:

```
Error: RequiredWith

  on test.tf line 3, in data "cidr_network" "test":
   3:   ip   = "192.168.2.57"

"ip": all of `ip,mask` must be specified
```

This pull requests fixes panic if no `mask` supplied.